### PR TITLE
Merge #92 into main

### DIFF
--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -241,7 +241,7 @@ export const GameBoard: React.FC = () => {
                       className="flex h-[100%] items-center justify-center"
                       draggable={isLeftSide && isPlayer1}
                       onClick={() => onViewTower(towerOnTile)}
-                      onDragStart={e =>
+                      onPointerDown={e =>
                         handleDragStart(
                           e,
                           towerOnTile.id,
@@ -251,7 +251,6 @@ export const GameBoard: React.FC = () => {
                         )
                       }
                       style={{
-                        touchAction: 'none',
                         transform:
                           towerOnTile.owner === game.player2Address
                             ? 'rotateY(180deg)'

--- a/packages/client/src/components/GameBoard.tsx
+++ b/packages/client/src/components/GameBoard.tsx
@@ -241,7 +241,7 @@ export const GameBoard: React.FC = () => {
                       className="flex h-[100%] items-center justify-center"
                       draggable={isLeftSide && isPlayer1}
                       onClick={() => onViewTower(towerOnTile)}
-                      onPointerDown={e =>
+                      onDragStart={e =>
                         handleDragStart(
                           e,
                           towerOnTile.id,

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -32,7 +32,7 @@ type GameContextType = {
   enemyCastlePosition: Castle;
   game: Game | null;
   handleDragStart: (
-    e: React.DragEvent<HTMLDivElement>,
+    e: React.PointerEvent<HTMLDivElement>,
     towerId: string,
     type: 'offense' | 'defense',
   ) => void;
@@ -396,7 +396,7 @@ export const GameProvider = ({
 
   const handleDragStart = useCallback(
     (
-      e: React.DragEvent<HTMLDivElement>,
+      e: React.PointerEvent<HTMLDivElement>,
       towerId: string,
       type: 'offense' | 'defense',
     ) => {

--- a/packages/client/src/contexts/GameContext.tsx
+++ b/packages/client/src/contexts/GameContext.tsx
@@ -32,7 +32,7 @@ type GameContextType = {
   enemyCastlePosition: Castle;
   game: Game | null;
   handleDragStart: (
-    e: React.PointerEvent<HTMLDivElement>,
+    e: React.DragEvent<HTMLDivElement>,
     towerId: string,
     type: 'offense' | 'defense',
   ) => void;
@@ -396,7 +396,7 @@ export const GameProvider = ({
 
   const handleDragStart = useCallback(
     (
-      e: React.PointerEvent<HTMLDivElement>,
+      e: React.DragEvent<HTMLDivElement>,
       towerId: string,
       type: 'offense' | 'defense',
     ) => {

--- a/packages/client/src/pages/Game.tsx
+++ b/packages/client/src/pages/Game.tsx
@@ -158,7 +158,7 @@ export const InnerGamePage = (): JSX.Element => {
                   className={`tower-card ${activeTowerId === tower.id ? 'selected' : ''} bg-gradient-to-b ${tower.color} cursor-pointer flex flex-col items-center min-w-[60px] p-2 rounded`}
                   draggable={isPlayer1}
                   onClick={() => handleTowerSelect(tower.id, tower.type)}
-                  onPointerDown={e => handleDragStart(e, tower.id, tower.type)}
+                  onDragStart={e => handleDragStart(e, tower.id, tower.type)}
                 >
                   <div className="flex h-8 items-center justify-center">
                     {tower.icon}

--- a/packages/client/src/pages/Game.tsx
+++ b/packages/client/src/pages/Game.tsx
@@ -158,10 +158,7 @@ export const InnerGamePage = (): JSX.Element => {
                   className={`tower-card ${activeTowerId === tower.id ? 'selected' : ''} bg-gradient-to-b ${tower.color} cursor-pointer flex flex-col items-center min-w-[60px] p-2 rounded`}
                   draggable={isPlayer1}
                   onClick={() => handleTowerSelect(tower.id, tower.type)}
-                  onDragStart={e => handleDragStart(e, tower.id, tower.type)}
-                  style={{
-                    touchAction: 'none',
-                  }}
+                  onPointerDown={e => handleDragStart(e, tower.id, tower.type)}
                 >
                   <div className="flex h-8 items-center justify-center">
                     {tower.icon}


### PR DESCRIPTION
This pull request includes changes to the drag-and-drop functionality in the game components by replacing `onPointerDown` with `onDragStart` events and updating the corresponding event types.

Drag-and-drop functionality updates:

* [`packages/client/src/components/GameBoard.tsx`](diffhunk://#diff-61cf99239a2e2a6b65d41737108f6537c7c6727c678f7a1931aff979bb3c920eL244-R244): Updated the `onPointerDown` event to `onDragStart` for handling drag start events on the game board.
* [`packages/client/src/pages/Game.tsx`](diffhunk://#diff-c7bce4107742f80e74bb073916d82516c64735ec48e825ac140a8d19beebc8f9L161-R161): Replaced the `onPointerDown` event with `onDragStart` for initiating drag events on tower cards.

Type updates for drag events:

* [`packages/client/src/contexts/GameContext.tsx`](diffhunk://#diff-62ec82c0fd2a643b5545f039749bdcce833caa53ca26a5148c04d22deb581095L35-R35): Changed the event type from `React.PointerEvent<HTMLDivElement>` to `React.DragEvent<HTMLDivElement>` in the `handleDragStart` function definition and its usage in the `GameProvider`. [[1]](diffhunk://#diff-62ec82c0fd2a643b5545f039749bdcce833caa53ca26a5148c04d22deb581095L35-R35) [[2]](diffhunk://#diff-62ec82c0fd2a643b5545f039749bdcce833caa53ca26a5148c04d22deb581095L399-R399)