### PR TITLE
Fix OwnerTowers bug

### DIFF
--- a/packages/contracts/src/Libraries/ProjectileHelpers.sol
+++ b/packages/contracts/src/Libraries/ProjectileHelpers.sol
@@ -262,22 +262,8 @@ library ProjectileHelpers {
   }
 
   function _removeDestroyedTower(bytes32 positionEntity) internal {
-    address ownerAddress = Owner.get(positionEntity);
     bytes32 gameId = CurrentGame.get(positionEntity);
-    bytes32 localOwnerId = EntityHelpers.localAddressToKey(gameId, ownerAddress);
 
-    bytes32[] memory ownerTowers = OwnerTowers.get(localOwnerId);
-    bytes32[] memory updatedTowers = new bytes32[](ownerTowers.length - 1);
-    uint256 index = 0;
-
-    for (uint256 i = 0; i < ownerTowers.length; i++) {
-      if (ownerTowers[i] != positionEntity) {
-        updatedTowers[index++] = ownerTowers[i];
-      }
-    }
-
-    OwnerTowers.set(localOwnerId, updatedTowers);
-    Owner.set(positionEntity, address(0));
     Health.set(positionEntity, 0, MAX_HEALTH_WALL);
     EntityAtPosition.set(
       EntityHelpers.positionToEntityKey(gameId, Position.getX(positionEntity), Position.getY(positionEntity)),


### PR DESCRIPTION
- The original bug in #121 couldn't be replicated, but this PR fixes a bug where if someone won with a tower that was destroyed on the same turn that they won, the `winner` address couldn't be fetched
- This is because the `winner` was pulled from the `OwnerTowers` list, and when the tower was destroyed, that information was removed
- Towers don't actually need to be removed from `OwnerTowers` when they are destroyed (it has no effect on the game), so the code for removing them was removed