### PR TITLE
Fake sure smart contract errors render correctly

### DIFF
--- a/packages/client/src/hooks/useMUD.ts
+++ b/packages/client/src/hooks/useMUD.ts
@@ -125,11 +125,29 @@ export const useMUD = (): {
     );
   }, [playerAddress]);
 
+  const publicClient = useMemo(
+    () =>
+      createPublicClient({
+        batch: { multicall: false },
+        chain: getGameChain(),
+        transport: http(),
+      }),
+    [],
+  );
+
   const buyElectricity = async (electricityAmount: bigint) => {
     try {
       if (!(worldContract && sync.data)) {
         throw new Error('World contract or sync data not found');
       }
+
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [electricityAmount],
+        functionName: 'app__buyElectricity',
+      });
 
       const tx = await worldContract.write.app__buyElectricity([
         electricityAmount,
@@ -156,6 +174,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [],
+        functionName: 'app__claimRecharge',
+      });
+
       const tx = await worldContract.write.app__claimRecharge();
       const txResult = await sync.data.waitForTransaction(tx);
       const { status } = txResult;
@@ -178,6 +204,14 @@ export const useMUD = (): {
       if (!(worldContract && sync.data)) {
         throw new Error('World contract or sync data not found');
       }
+
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [username, resetLevel],
+        functionName: 'app__createGame',
+      });
 
       const tx = await worldContract.write.app__createGame(
         [username, resetLevel],
@@ -208,6 +242,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [savedModificationId as `0x${string}`],
+        functionName: 'app__deleteModification',
+      });
+
       const tx = await worldContract.write.app__deleteModification([
         savedModificationId as `0x${string}`,
       ]);
@@ -237,6 +279,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [savedModificationId as `0x${string}`, description, name],
+        functionName: 'app__editModification',
+      });
+
       const tx = await worldContract.write.app__editModification([
         savedModificationId as `0x${string}`,
         description,
@@ -264,6 +314,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [],
+        functionName: 'app__forfeitRun',
+      });
+
       const tx = await worldContract.write.app__forfeitRun();
       const txResult = await sync.data.waitForTransaction(tx);
       const { status } = txResult;
@@ -287,12 +345,6 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
-      const publicClient = createPublicClient({
-        chain: getGameChain(),
-        transport: http(),
-        batch: { multicall: false },
-      });
-
       const simulatedTx = await publicClient.simulateContract({
         abi: worldContract.abi,
         address: worldContract.address,
@@ -312,6 +364,14 @@ export const useMUD = (): {
       if (!(worldContract && sync.data)) {
         throw new Error('World contract or sync data not found');
       }
+
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [projectile, x, y],
+        functionName: 'app__playerInstallTower',
+      });
 
       const tx = await worldContract.write.app__playerInstallTower([
         projectile,
@@ -344,6 +404,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [towerId as `0x${string}`, bytecode as `0x${string}`, sourceCode],
+        functionName: 'app__playerModifyTowerSystem',
+      });
+
       const tx = await worldContract.write.app__playerModifyTowerSystem([
         towerId as `0x${string}`,
         bytecode as `0x${string}`,
@@ -371,6 +439,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [towerId as `0x${string}`, x, y],
+        functionName: 'app__playerMoveTower',
+      });
+
       const tx = await worldContract.write.app__playerMoveTower([
         towerId as `0x${string}`,
         x,
@@ -397,6 +473,14 @@ export const useMUD = (): {
       if (!(worldContract && sync.data)) {
         throw new Error('World contract or sync data not found');
       }
+
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [gameId as `0x${string}`],
+        functionName: 'app__nextTurn',
+      });
 
       const tx = await worldContract.write.app__nextTurn([
         gameId as `0x${string}`,
@@ -428,6 +512,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [bytecode as `0x${string}`, description, name, sourceCode],
+        functionName: 'app__saveModification',
+      });
+
       const tx = await worldContract.write.app__saveModification([
         bytecode as `0x${string}`,
         description,
@@ -456,6 +548,14 @@ export const useMUD = (): {
         throw new Error('World contract or sync data not found');
       }
 
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [electricityAmount],
+        functionName: 'app__sellElectricity',
+      });
+
       const tx = await worldContract.write.app__sellElectricity([
         electricityAmount,
       ]);
@@ -480,6 +580,15 @@ export const useMUD = (): {
       if (!(worldContract && sync.data)) {
         throw new Error('World contract or sync data not found');
       }
+
+      await publicClient.simulateContract({
+        abi: worldContract.abi,
+        account: playerAddress,
+        address: worldContract.address,
+        args: [electricityAmount],
+        functionName: 'app__sellElectricityThroughRelay',
+      });
+
       const tx = await worldContract.write.app__sellElectricityThroughRelay([
         electricityAmount,
       ]);


### PR DESCRIPTION
- Problem: since upgrading to the latest version of MUD (or, more likely, `viem`), transactions were not returning the revert error
- Solution: all game transactions are now simulated first, which returns the inevitable revert message if the transaction were to fail