### PR TITLE
Check all kingdoms between current and top level before returning stake

### DIFF
--- a/packages/contracts/src/Libraries/BattleHelpers.sol
+++ b/packages/contracts/src/Libraries/BattleHelpers.sol
@@ -168,7 +168,13 @@ library BattleHelpers {
         return;
       }
 
-      TowerHelpers.moveTower(globalPlayer2Id, CurrentBattle.get(globalPlayer1Id), towerEntity, action.newX, action.newY);
+      TowerHelpers.moveTower(
+        globalPlayer2Id,
+        CurrentBattle.get(globalPlayer1Id),
+        towerEntity,
+        action.newX,
+        action.newY
+      );
     } else if (action.actionType == ActionType.Modify) {
       ProjectileData memory projectileData = Projectile.get(actionIds[actionIdIndex]);
       bytes32 towerEntity = EntityAtPosition.get(EntityHelpers.positionToEntityKey(battleId, action.oldX, action.oldY));


### PR DESCRIPTION
- Previously, `_processPotentialStakeReturn` only checked the current level for playable kingdoms
- Now, it checks all kingdoms between the current and the top level
- This involves a lot of looping, and isn't ideal at all. Need to return to this in the future to make it more efficient