### PR TITLE
chore: lower faucet rate limit time

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -61,8 +61,8 @@ const ALERT_INTERVAL_MS = 1000 * 60 * 60; // 1 hour cooldown
 // In-memory rate limits for faucet
 const ipTimestamps = new Map();
 const addressTimestamps = new Map();
-const FAUCET_INTERVAL = 1000 * 60 * 60 * 1; // 1 hour
-const FAUCET_AMOUNT = parseEther("0.000002"); // Around $0.004 right now
+const FAUCET_INTERVAL = 1000 * 60 * 1 * 1; // 1 minute
+const FAUCET_AMOUNT = parseEther("0.000004"); // Around $0.008 right now
 
 const port = process.env.PORT || 3002;
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -76,7 +76,7 @@ export const App = (): JSX.Element => {
           });
           // eslint-disable-next-line no-console
           console.info(`[Faucet]: Player balance -> ${balance}`);
-          const lowBalance = balance < parseEther('0.000001');
+          const lowBalance = balance < parseEther('0.000004');
           if (lowBalance) {
             // eslint-disable-next-line no-console
             console.info('[Faucet]: Balance is low, dripping funds to player');


### PR DESCRIPTION
This pull request updates the faucet logic to adjust the cooldown interval and the amount of funds distributed, as well as the threshold for triggering a low-balance alert. These changes are aimed at improving user experience by reducing wait times and ensuring sufficient funds are provided.

### Faucet logic updates:

* [`packages/api/index.js`](diffhunk://#diff-f495914c15883ca23896892a98d9157204e68c06a8f935ce9ee750d049c32a42L64-R65): Reduced the faucet cooldown interval from 1 hour to 1 minute and increased the faucet amount from `0.000002` ETH to `0.000004` ETH.
* [`packages/client/src/App.tsx`](diffhunk://#diff-ec2dc392bcf26c2a7c1a34631db8a5f5d220596d2e986f8959acaa22494fcb78L79-R79): Updated the low-balance threshold from `0.000001` ETH to `0.000004` ETH to align with the increased faucet amount.