### PR TITLE
feat: send email alert after validator signatures

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -134,7 +134,7 @@ app.post("/api/faucet", async (req, res) => {
         await sgMail.send({
           to: alertEmail,
           from: alertEmail,
-          subject: "⚠️ Faucet balance is low!",
+          subject: "Auto Tower Defense - ⚠️ Faucet balance is low!",
           text: `Your faucet has a low balance: ${balanceEth} ETH remaining on chain ID ${chainId}. Please refill it soon to keep the faucet operational.`,
         });
         lastAlertSent = now;
@@ -274,6 +274,17 @@ app.post("/buy-validator-signature", async (req, res) => {
     const signature = await walletClient.signMessage({
       message: { raw: structHash },
     });
+
+    try {
+      await sgMail.send({
+        to: alertEmail,
+        from: alertEmail,
+        subject: "Auto Tower Defense - Buy Validator Signature Request",
+        text: `A buy validator signature request was made with the following details:\n\nAmount: ${amount}\nBuyer: ${buyer}\nDestination Chain ID: ${destinationChainId}\nNonce: ${nonce}\nOrigin Chain ID: ${originChainId}\nTransaction Hash: ${txHash}\n\nSignature: ${signature}.`,
+      });
+    } catch (emailErr) {
+      console.error("SendGrid error:", emailErr);
+    }
     res.json({ signature });
   } catch (err) {
     console.error(err);
@@ -372,6 +383,18 @@ app.post("/sell-validator-signature", async (req, res) => {
     const signature = await walletClient.signMessage({
       message: { raw: structHash },
     });
+
+    try {
+      await sgMail.send({
+        to: alertEmail,
+        from: alertEmail,
+        subject: "Auto Tower Defense - Sell Validator Signature Request",
+        text: `A sell validator signature request was made with the following details:\n\nAmount: ${amount}\nSeller: ${seller}\nDestination Chain ID: ${destinationChainId}\nNonce: ${nonce}\nOrigin Chain ID: ${originChainId}\nTransaction Hash: ${txHash}\n\nSignature: ${signature}.`,
+      });
+    } catch (emailErr) {
+      console.error("SendGrid error:", emailErr);
+    }
+
     res.json({ signature });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
This pull request adds email notifications for specific API operations and updates the subject line for an existing email alert to include the application name. These changes enhance monitoring and provide better context in email notifications.

### Email notification improvements:

* **Faucet alert email subject updated**: The subject line for the low faucet balance alert now includes the application name, "Auto Tower Defense," to provide better context. (`packages/api/index.js`, [packages/api/index.jsL137-R137](diffhunk://#diff-f495914c15883ca23896892a98d9157204e68c06a8f935ce9ee750d049c32a42L137-R137))

* **Buy validator signature request notification**: Added a new email notification when a buy validator signature request is made. The email includes details such as the amount, buyer, destination chain ID, nonce, origin chain ID, transaction hash, and signature. (`packages/api/index.js`, [packages/api/index.jsR277-R287](diffhunk://#diff-f495914c15883ca23896892a98d9157204e68c06a8f935ce9ee750d049c32a42R277-R287))

* **Sell validator signature request notification**: Added a new email notification for sell validator signature requests, including similar details as the buy request notification (amount, seller, destination chain ID, nonce, origin chain ID, transaction hash, and signature). (`packages/api/index.js`, [packages/api/index.jsR386-R397](diffhunk://#diff-f495914c15883ca23896892a98d9157204e68c06a8f935ce9ee750d049c32a42R386-R397))