### PR TITLE
chore: tweak README to match new game description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auto Tower Defense
 
-Auto Tower Defense is a pay-to-learn game that turns into a play-to-earn game once you've mastered the core skills required to be good. Right now, the skill it teaches is Solidity, but this can extend to many other areas in the future.
+Auto Tower Defense is a strategy game for both battlers and builders. Battle to become the top kingdom, or build and patent tower components to earn royalties. Whether you're a tactician or an engineer, there's a path to victory.
 
 ## Overview
 
@@ -9,6 +9,8 @@ Auto Tower Defense is a mix of a tower defense game and a game of chess, but wit
 1. A tower's underlying components code can be modified by the player using Solidity
 2. When a player wins a battle, that battle is saved as an additional possible opponent for future players to face at that level. So, the more players play, the more the game grows
 3. Any player can license out any other player's tower component patents, but if the first player earns money in a win, a portion of that winning goes to the player they licensed the patent from
+
+Get a deeper look into the game mechanics [here](https://paragraph.com/@raidguild-forge/introducing-auto-tower-defense).
 
 ## Prerequisites
 

--- a/packages/client/src/pages/Home.tsx
+++ b/packages/client/src/pages/Home.tsx
@@ -372,10 +372,9 @@ export const Home = (): JSX.Element => {
       </h1>
 
       <p className="text-gray-300 text-center text-lg max-w-lg mx-auto mt-3 mb-6">
-        Play a strategy game for both battlers and builders. Battle to become
-        the top kingdom, or build and patent tower components to earn royalties.
-        Whether you&apos;re a tactician or an engineer, there&apos;s a path to
-        victory.
+        A strategy game for both battlers and builders. Battle to become the top
+        kingdom, or build and patent tower components to earn royalties. Whether
+        you&apos;re a tactician or an engineer, there&apos;s a path to victory.
       </p>
 
       {PlayerCountDisplay}


### PR DESCRIPTION
This pull request updates the description and messaging for the Auto Tower Defense game to better reflect its gameplay and appeal. Changes include revisions to the `README.md` file and the homepage text in the client application.

### Updates to game description:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Revised the game description to emphasize its dual appeal to strategists and engineers, highlighting the ability to battle for dominance or build and patent tower components for royalties. Added a link to a detailed explanation of the game mechanics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13-R14)

### Updates to homepage text:

* [`packages/client/src/pages/Home.tsx`](diffhunk://#diff-365299ef80a402ebd257005bfb5e7b5ac1724f8ba24072d8e6c488a5968f03dcL375-R377): Adjusted the homepage messaging to align with the updated game description, removing redundant phrasing while maintaining clarity.