### PR TITLE
fix: render UserOperation error as low funds error

### DIFF
--- a/packages/client/src/hooks/useMUD.ts
+++ b/packages/client/src/hooks/useMUD.ts
@@ -28,7 +28,10 @@ const getContractError = (error: BaseError): string => {
 
   if (error instanceof UserOperationExecutionError) {
     const errorMessage = error.cause.shortMessage;
-    if (errorMessage.includes('sufficient funds')) {
+    if (
+      errorMessage.includes('sufficient funds') ||
+      errorMessage.includes('UserOperation reverted during simulation')
+    ) {
       return 'Insufficient funds. Please top up your account.';
     }
     return (


### PR DESCRIPTION
Not the best solution. But it'll do for now.

---

This pull request updates the error handling logic in the `getContractError` function within the `useMUD.ts` file to account for an additional error scenario.

Error handling improvement:

* [`packages/client/src/hooks/useMUD.ts`](diffhunk://#diff-c5166c69058bd56aae74e88f50e14a7f7cae8e464733ef6823905297e8acca2dL31-R34): Enhanced the `getContractError` function to include a check for the error message "UserOperation reverted during simulation," ensuring that this case is mapped to the "Insufficient funds" error message for better user feedback.