### PR TITLE
fix: hide battle control buttons when not player 1 of that battle

### DIFF
--- a/packages/client/src/components/BattleControlButtons.tsx
+++ b/packages/client/src/components/BattleControlButtons.tsx
@@ -15,8 +15,14 @@ type BattleControlButtonsProps = {
 export const BattleControlButtons: React.FC<BattleControlButtonsProps> = ({
   setIsHelpDialogOpen,
 }) => {
-  const { battle, isChangingTurn, isUndoing, onNextTurn, onUndoAction } =
-    useBattle();
+  const {
+    battle,
+    isChangingTurn,
+    isPlayer1,
+    isUndoing,
+    onNextTurn,
+    onUndoAction,
+  } = useBattle();
   const { tutorialStep } = useTutorialIndicator();
 
   return (
@@ -30,38 +36,42 @@ export const BattleControlButtons: React.FC<BattleControlButtonsProps> = ({
         <HelpCircle className="h-4 mr-1 w-4" />
         Help
       </Button>
-      <Button
-        className="border-orange-500 hover:bg-orange-950/50 hover:text-orange-400 text-orange-400"
-        disabled={isUndoing || battle?.actionCount === 2}
-        onClick={onUndoAction}
-        size="sm"
-        variant="outline"
-      >
-        {isUndoing ? (
-          <Loader2 className=" animate-spin h-6 w-6" />
-        ) : (
-          <Undo2 className="h-4 w-4 mr-1" />
-        )}
-        Undo
-      </Button>
-      <div className="relative">
-        <Button
-          className="bg-cyan-800 hover:bg-cyan-700 text-white"
-          disabled={isChangingTurn}
-          onClick={onNextTurn}
-          size="sm"
-        >
-          {isChangingTurn ? (
-            <Loader2 className=" animate-spin h-6 w-6" />
-          ) : (
-            <StopCircle className="h-4 w-4 mr-1" />
-          )}
-          End turn
-        </Button>
-        {(tutorialStep === TutorialSteps.THREE_THREE ||
-          tutorialStep === TutorialSteps.FOUR_SEVEN) &&
-          !isChangingTurn && <ClickIndicator />}
-      </div>
+      {isPlayer1 && (
+        <>
+          <Button
+            className="border-orange-500 hover:bg-orange-950/50 hover:text-orange-400 text-orange-400"
+            disabled={isUndoing || battle?.actionCount === 2}
+            onClick={onUndoAction}
+            size="sm"
+            variant="outline"
+          >
+            {isUndoing ? (
+              <Loader2 className=" animate-spin h-6 w-6" />
+            ) : (
+              <Undo2 className="h-4 w-4 mr-1" />
+            )}
+            Undo
+          </Button>
+          <div className="relative">
+            <Button
+              className="bg-cyan-800 hover:bg-cyan-700 text-white"
+              disabled={isChangingTurn}
+              onClick={onNextTurn}
+              size="sm"
+            >
+              {isChangingTurn ? (
+                <Loader2 className=" animate-spin h-6 w-6" />
+              ) : (
+                <StopCircle className="h-4 w-4 mr-1" />
+              )}
+              End turn
+            </Button>
+            {(tutorialStep === TutorialSteps.THREE_THREE ||
+              tutorialStep === TutorialSteps.FOUR_SEVEN) &&
+              !isChangingTurn && <ClickIndicator />}
+          </div>
+        </>
+      )}
     </>
   );
 };

--- a/packages/client/src/pages/Battle.tsx
+++ b/packages/client/src/pages/Battle.tsx
@@ -246,17 +246,19 @@ export const InnerBattlePage = (): JSX.Element => {
             Home
           </Button>
         </div>
-        <div className="fixed right-4 text-cyan-400 text-sm top-4 z-10">
-          <Button
-            className="text-gray-500 hover:text-red-400 hover:bg-red-900/10"
-            onClick={() => setShowForfeitDialog(true)}
-            size="sm"
-            variant="ghost"
-          >
-            <Flag className="h-4 w-4 mr-1" />
-            Forfeit
-          </Button>
-        </div>
+        {isPlayer1 && (
+          <div className="fixed right-4 text-cyan-400 text-sm top-4 z-10">
+            <Button
+              className="text-gray-500 hover:text-red-400 hover:bg-red-900/10"
+              onClick={() => setShowForfeitDialog(true)}
+              size="sm"
+              variant="ghost"
+            >
+              <Flag className="h-4 w-4 mr-1" />
+              Forfeit
+            </Button>
+          </div>
+        )}
 
         {/* Battery Information - Desktop (fixed position) */}
         {batteryDetails && (


### PR DESCRIPTION
This pull request introduces conditional rendering based on the `isPlayer1` property to enhance the user interface for player-specific actions in the battle component and battle page. The changes ensure that certain buttons and UI elements are only visible to Player 1, improving the experience for multiplayer scenarios.

### Enhancements to Player-Specific UI:

#### In `BattleControlButtons` (`packages/client/src/components/BattleControlButtons.tsx`):
* Added the `isPlayer1` property from the `useBattle` hook to conditionally render buttons for Player 1.
* Modified the rendering logic to display specific buttons, such as the undo action button, only when `isPlayer1` is true. [[1]](diffhunk://#diff-1cfb312da1cdd8bf0c71077f11e54ea22199113ab3fa9125379fad43a1bb4e50R39-R40) [[2]](diffhunk://#diff-1cfb312da1cdd8bf0c71077f11e54ea22199113ab3fa9125379fad43a1bb4e50R74-R75)

#### In `Battle` page (`packages/client/src/pages/Battle.tsx`):
* Added conditional rendering for the "Forfeit" button, ensuring it appears only for Player 1. [[1]](diffhunk://#diff-e46d2c02dc7a6bfde1d5da82cd30f9afc3cc90edfcd58b90b493dfb1ba1351ebR249) [[2]](diffhunk://#diff-e46d2c02dc7a6bfde1d5da82cd30f9afc3cc90edfcd58b90b493dfb1ba1351ebR261)