### PR TITLE
fix: bring back original syncing logic

### DIFF
--- a/packages/client/src/mud/Synced.tsx
+++ b/packages/client/src/mud/Synced.tsx
@@ -13,10 +13,10 @@ export type SyncedProps = {
 
 export const Synced = ({ children, fallback }: SyncedProps): ReactNode => {
   const status = useSyncStatus();
-  // TODO: Remove temporary workaround once indexer issue is resolved
-  // return status.isLive ? children : fallback?.(status);
-  return status.latestBlockNumber > 0n &&
-    status.lastBlockNumberProcessed >= status.latestBlockNumber - 4n
-    ? children
-    : fallback?.(status);
+  return status.isLive ? children : fallback?.(status);
+  // Use if indexer is lagging behind
+  // return status.latestBlockNumber > 0n &&
+  //   status.lastBlockNumberProcessed >= status.latestBlockNumber - 4n
+  //   ? children
+  //   : fallback?.(status);
 };


### PR DESCRIPTION
This pull request simplifies the logic in the `Synced` component by reverting to the original `status.isLive` check and commenting out the temporary workaround for indexer lag. This cleanup improves readability and prepares the code for future resolution of the indexer issue.

Key change:

* [`packages/client/src/mud/Synced.tsx`](diffhunk://#diff-bb56f22fbb728633c2f0e6ec448b1eca2c44d650040df38efeb95a28e22257c5L16-R21): Reverted the `return` logic to use `status.isLive` directly, while commenting out the workaround for indexer lagging behind.