### PR TITLE
feat: show USD value of electricity in key areas

### DIFF
--- a/packages/client/src/components/dialogs/AsyncRevenueDialog.tsx
+++ b/packages/client/src/components/dialogs/AsyncRevenueDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useMUD } from '@/hooks/useMUD';
-import { formatWattHours } from '@/utils/helpers';
+import { formatWattHours, wattToUsdc } from '@/utils/helpers';
 
 const ASYNC_REVENUE_TIMESTAMP_KEY = 'async-kingdom-revenue-timestamp';
 
@@ -98,8 +98,12 @@ export const AsyncRevenueDialog: React.FC = () => {
           </DialogTitle>
           <DialogDescription className="mt-2 text-gray-300">
             Congrats! Your kingdoms have earned you{' '}
-            <strong>{formatWattHours(revenueSinceTimestamp)}</strong> in the
-            last <strong>{timeSinceLastCheck}</strong>.
+            <span className="font-medium text-blue-400">
+              {formatWattHours(revenueSinceTimestamp)} (
+              {wattToUsdc(revenueSinceTimestamp)})
+            </span>{' '}
+            in the last{' '}
+            <span className="font-medium">{timeSinceLastCheck}</span>.
           </DialogDescription>
         </DialogHeader>
 

--- a/packages/client/src/components/dialogs/BatteryInfoDialog.tsx
+++ b/packages/client/src/components/dialogs/BatteryInfoDialog.tsx
@@ -82,9 +82,10 @@ export const BatteryInfoDialog: React.FC<BatteryInfoDialogProps> = ({
                 Battery System
               </h3>
               <p className="text-gray-200">
-                Your battery has a capacity of 24 kWh. Each battle run costs{' '}
-                <span className="font-semibold text-white">8 kWh</span> to run.
-                The battery naturally recharges over time.
+                Your battery has a capacity of 24 kWh ($0.12). Each battle run
+                costs{' '}
+                <span className="font-semibold text-white">8 kWh ($0.04)</span>{' '}
+                to run. The battery naturally recharges over time.
               </p>
             </div>
           </div>

--- a/packages/client/src/utils/helpers.ts
+++ b/packages/client/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { garnet, pyrope } from '@latticexyz/common/chains';
-import { Chain } from 'viem';
+import { Chain, formatUnits } from 'viem';
 import { anvil, base, baseSepolia, redstone } from 'viem/chains';
 
 import { CHAIN_ID, SUPPORTED_CHAINS, WORLD_ADDRESS } from './constants';
@@ -125,4 +125,9 @@ export const getChainLogo = (chainId?: number): string => {
     default:
       return '';
   }
+};
+
+export const wattToUsdc = (watt: bigint): string => {
+  const usdcValue = watt / BigInt(1920); // $0.01 per 1.92 watt hours
+  return `$${Number(formatUnits(usdcValue, 2))}`;
 };


### PR DESCRIPTION
This pull request enhances the user experience by introducing a conversion feature that displays energy values in both watt-hours and their equivalent monetary value (USD). Additionally, it adds a helper function for the conversion logic in the utilities file.

### Feature Enhancements: Energy-to-Money Conversion
* [`packages/client/src/components/dialogs/AsyncRevenueDialog.tsx`](diffhunk://#diff-1fd25c9178c017fb79587306196762835d70e6d4cc87e4df4825fe664488a4b6L101-R106): Updated the `AsyncRevenueDialog` to display energy revenue (`revenueSinceTimestamp`) both in watt-hours and its monetary equivalent (USD) using the new `wattToUsdc` function.
* [`packages/client/src/components/dialogs/BatteryInfoDialog.tsx`](diffhunk://#diff-8e8e9f7dcd2155b077b56efde617220da85a6a6bf69ae92e248c7d271a4a79c1L85-R88): Modified battery information to include monetary equivalents for battery capacity and battle run costs.

### Utility Updates: Conversion Logic
* [`packages/client/src/utils/helpers.ts`](diffhunk://#diff-e6a1e48d1704798904bf67ab33d0a5dad873277138615e2cc604e62a9bddccdcR129-R133): Added the `wattToUsdc` helper function to convert watt-hours to USD based on a fixed rate. Imported `formatUnits` from `viem` to format monetary values. [[1]](diffhunk://#diff-e6a1e48d1704798904bf67ab33d0a5dad873277138615e2cc604e62a9bddccdcR129-R133) [[2]](diffhunk://#diff-e6a1e48d1704798904bf67ab33d0a5dad873277138615e2cc604e62a9bddccdcL2-R2)

### Code Integration
* [`packages/client/src/components/dialogs/AsyncRevenueDialog.tsx`](diffhunk://#diff-1fd25c9178c017fb79587306196762835d70e6d4cc87e4df4825fe664488a4b6L16-R16): Imported the new `wattToUsdc` function for use in the `AsyncRevenueDialog`.