### PR TITLE
feat: darken tower color if modified

### DIFF
--- a/packages/client/src/components/BattleBoard.tsx
+++ b/packages/client/src/components/BattleBoard.tsx
@@ -1,4 +1,6 @@
 import { useDndContext } from '@dnd-kit/core';
+import { useComponentValue } from '@latticexyz/react';
+import { singletonEntity } from '@latticexyz/store-sync/recs';
 import { Binoculars, Loader2, Wrench } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -52,6 +54,7 @@ const GRID_COLS = 14;
 
 export const BattleBoard: React.FC = () => {
   const {
+    components: { DefaultLogic },
     network: { globalPlayerId },
   } = useMUD();
   const {
@@ -77,6 +80,11 @@ export const BattleBoard: React.FC = () => {
   const [selectedTower, setSelectedTower] = useState<Tower | null>(null);
   const [isAssemblyDrawerOpen, setIsAssemblyDrawerOpen] = useState(false);
   const [tooltipSelection, setTooltipSelection] = useState<string | null>(null);
+
+  const defaultLogicAddress = useComponentValue(
+    DefaultLogic,
+    singletonEntity,
+  )?.value;
 
   const onViewTower = useCallback(
     (tower: Tower) => {
@@ -324,8 +332,14 @@ export const BattleBoard: React.FC = () => {
                                     <GiCannon
                                       className={
                                         isLeftSide
-                                          ? 'text-cyan-400'
-                                          : 'text-pink-400'
+                                          ? towerOnTile.projectileLogicAddress ===
+                                            defaultLogicAddress
+                                            ? 'text-cyan-400'
+                                            : 'text-blue-600'
+                                          : towerOnTile.projectileLogicAddress ===
+                                              defaultLogicAddress
+                                            ? 'text-pink-400'
+                                            : 'text-red-600'
                                       }
                                       size={28}
                                     />


### PR DESCRIPTION
This pull request introduces changes to the `BattleBoard` component to enhance its functionality by integrating logic for handling default logic addresses and updating UI behavior based on these addresses. The updates primarily focus on improving the dynamic styling of tower elements and adding new dependencies for state management.

### Integration of default logic address:

* [`packages/client/src/components/BattleBoard.tsx`](diffhunk://#diff-7cd7343e845bfb688abafb8922dafab72532b1e8457cf40f2ebbe999dceb6d3aR2-R3): Added `useComponentValue` and `singletonEntity` imports to manage state and retrieve the default logic address.
* [`packages/client/src/components/BattleBoard.tsx`](diffhunk://#diff-7cd7343e845bfb688abafb8922dafab72532b1e8457cf40f2ebbe999dceb6d3aR84-R88): Introduced a new `defaultLogicAddress` variable using `useComponentValue` to fetch the value from the `DefaultLogic` component.

### Dynamic UI styling based on logic address:

* [`packages/client/src/components/BattleBoard.tsx`](diffhunk://#diff-7cd7343e845bfb688abafb8922dafab72532b1e8457cf40f2ebbe999dceb6d3aR335-R342): Updated the conditional styling of tower elements (`GiCannon`) to dynamically change colors based on whether the `projectileLogicAddress` matches the `defaultLogicAddress`.

### Component structure update:

* [`packages/client/src/components/BattleBoard.tsx`](diffhunk://#diff-7cd7343e845bfb688abafb8922dafab72532b1e8457cf40f2ebbe999dceb6d3aR57): Added `DefaultLogic` to the `components` object within the `useMUD` hook to access the necessary logic for state management.