### PR TITLE
fix: correct action amount in HowToPlayDialog

### DIFF
--- a/packages/client/src/components/dialogs/HowToPlayDialog.tsx
+++ b/packages/client/src/components/dialogs/HowToPlayDialog.tsx
@@ -81,7 +81,7 @@ export const HowToPlayDialog: React.FC<HowToPlayDialogProps> = ({
               </li>
               <li>
                 Each turn, you can perform{' '}
-                <span className="text-white font-semibold">1 action</span>:
+                <span className="text-white font-semibold">2 actions</span>:
                 install a tower, move a tower, or modify a tower.
               </li>
               <li>


### PR DESCRIPTION
This pull request updates the gameplay instructions in the `HowToPlayDialog` component to reflect a change in the number of actions players can perform per turn.

* [`packages/client/src/components/dialogs/HowToPlayDialog.tsx`](diffhunk://#diff-ad49f7abcf7e2f43e5680ca392bf44ee0faefa00d836dd67fcf3bc97ae3e1db2L84-R84): Updated the text to indicate that players can now perform "2 actions" per turn instead of "1 action" in the gameplay instructions.