### PR TITLE
fix: close no actions dialog after turn changes

### DIFF
--- a/packages/client/src/components/dialogs/NoActionsDialog.tsx
+++ b/packages/client/src/components/dialogs/NoActionsDialog.tsx
@@ -39,9 +39,7 @@ export const NoActionsDialog: React.FC = () => {
         <DialogFooter className="sm:justify-center">
           <Button
             disabled={isChangingTurn}
-            onClick={() =>
-              onNextTurn().then(() => setIsNoActionsDialogOpen(false))
-            }
+            onClick={onNextTurn}
             className="bg-pink-800 hover:bg-pink-700 text-white w-full"
           >
             {isChangingTurn ? (

--- a/packages/client/src/contexts/BattleContext.tsx
+++ b/packages/client/src/contexts/BattleContext.tsx
@@ -523,6 +523,7 @@ export const BattleProvider = ({
       }
 
       const newBattle = getComponentValue(BattleComponent, battle.id as Entity);
+      setIsNoActionsDialogOpen(false);
       if (newBattle && newBattle.endTimestamp === BigInt(0)) {
         const { error, success } = await nextTurn(battle.id);
 


### PR DESCRIPTION
This pull request refactors the handling of the "No Actions" dialog in the client application to improve code clarity and maintainability. The main changes involve simplifying the `onClick` handler in the `NoActionsDialog` component and ensuring the dialog state is properly managed in the `BattleProvider` context.

### Changes to `NoActionsDialog` component:

* Simplified the `onClick` handler for the "Next Turn" button by directly passing the `onNextTurn` function, removing the inline logic that closed the dialog after the action was completed. (`[packages/client/src/components/dialogs/NoActionsDialog.tsxL42-R42](diffhunk://#diff-36b7447e2c0fd672381c92b1f2f5849a3d388c80e8f3d0abf0a3bb81e9ebbb22L42-R42)`)

### Changes to `BattleProvider` context:

* Added a call to `setIsNoActionsDialogOpen(false)` to explicitly close the "No Actions" dialog when processing a new battle turn, ensuring consistent state management. (`[packages/client/src/contexts/BattleContext.tsxR526](diffhunk://#diff-292c4a9230a678f854dfe0bc2335a449e80df0f5d791fdbab478670879227ba5R526)`)