### PR TITLE
fix: patents list auto-scroll issue

### DIFF
--- a/packages/client/src/components/PatentsList.tsx
+++ b/packages/client/src/components/PatentsList.tsx
@@ -52,21 +52,22 @@ export const PatentsList: React.FC<PatentsListProps> = ({
   }, [myUsername, patents]);
 
   const scrollToRow = useCallback(() => {
-    const index = patents.findIndex(s => s.id === selectedPatent.id);
+    const patentsToUse = patentsTab === 'your' ? myPatents : otherPatents;
+    if (patentsToUse.length === 0) return;
+    const index = patentsToUse.findIndex(s => s.id === selectedPatent.id);
     const container = innerRef.current as unknown as HTMLDivElement;
     const row = rowRefs.current[index];
+
     if (container && row) {
-      // compute the row's position relative to the container
-      const containerRect = container.getBoundingClientRect();
-      const rowRect = row.getBoundingClientRect();
-      const offset = rowRect.top - containerRect.top + container.scrollTop;
+      const rowHeight = 58;
+      const offset = index * rowHeight;
 
       container.scrollTo({
         top: offset,
         behavior: 'smooth',
       });
     }
-  }, [patents, rowRefs, selectedPatent]);
+  }, [myPatents, otherPatents, patentsTab, rowRefs, selectedPatent]);
 
   useEffect(() => {
     scrollToRow();


### PR DESCRIPTION
This pull request updates the `PatentsList` component to improve how the selected patent is scrolled into view. The changes include conditionally using different patent lists based on the active tab and simplifying the scroll position calculation.

### Updates to scrolling logic:

* `packages/client/src/components/PatentsList.tsx`:
  - Introduced a conditional check to use either `myPatents` or `otherPatents` based on the `patentsTab` value, ensuring the correct list is used for scrolling. Added a safeguard to exit early if the selected list is empty.
  - Simplified the scroll offset calculation by replacing the DOM-based computation with a fixed row height (`58`) multiplied by the index of the selected patent.
  - Updated dependencies in the `useCallback` hook to include `myPatents`, `otherPatents`, and `patentsTab`.