### PR TITLE
feat: open settings dialog on esc key press

### DIFF
--- a/packages/client/src/components/dialogs/SettingsDialog.tsx
+++ b/packages/client/src/components/dialogs/SettingsDialog.tsx
@@ -130,6 +130,20 @@ export const SettingsDialog: React.FC = () => {
     }
   }, []);
 
+  // Open dialog when 'esc' is clicked
+  useEffect(() => {
+    if (open) return () => undefined;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !e.defaultPrevented && !e.repeat) {
+        setOpen(true);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
   const handleMusicToggle = (enabled: boolean) => {
     const _newSettings = { ...settings, musicEnabled: enabled };
     setSettings(_newSettings);
@@ -174,6 +188,7 @@ export const SettingsDialog: React.FC = () => {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
+          onOpenAutoFocus={e => e.preventDefault()}
           aria-describedby={undefined}
           className="bg-gray-900/95 border border-cyan-900/50 text-white"
         >
@@ -184,10 +199,7 @@ export const SettingsDialog: React.FC = () => {
           </DialogHeader>
 
           <div className="mt-4 space-y-6">
-            <div
-              className="flex justify-center mb-8"
-              onClick={() => setOpen(false)}
-            >
+            <div className="mb-8 mx-auto w-fit" onClick={() => setOpen(false)}>
               <AccountButton />
             </div>
 


### PR DESCRIPTION
Based on https://github.com/ECWireless/auto-tower-defense/compare/dev...nayasinghania:auto-tower-defense:dev by @nayasinghania 

---

This pull request enhances the `SettingsDialog` component by improving its accessibility and user interaction. The most notable changes include allowing the dialog to be opened with the Escape key, updating dialog focus behavior, and refining the layout of the account button.

**Accessibility and interaction improvements:**

* Added a `useEffect` hook to allow opening the `SettingsDialog` when the Escape key is pressed, improving keyboard accessibility.
* Prevented the dialog from auto-focusing on open by using the `onOpenAutoFocus` prop with `e.preventDefault()`, ensuring a smoother user experience.

**UI layout refinements:**

* Updated the container for the `AccountButton` to use centered and width-fitting styles, simplifying the layout and maintaining the close-on-click behavior.